### PR TITLE
Single gene iModulon method

### DIFF
--- a/pymodulon/core.py
+++ b/pymodulon/core.py
@@ -254,12 +254,18 @@ class IcaData(object):
 
         return final_rows
 
-    def single_gene_imodulons(self) -> List[ImodName]:
+    def find_single_gene_imodulons(self) -> List[ImodName]:
         """
-        A simple function that returns the names of all single-gene iModulons based on the current threshold values
+        A simple function that returns the names of all likely single-gene iModulons. Checks if the largest iModulon
+        gene weight is more than twice the weight of the second highest iModulon gene weight.
         :return single_genes_imodulons: the current single-gene iModulon names
         """
-        return [iM for iM in self.imodulon_names if sum(abs(self.M[iM]) > self.thresholds[iM]) == 1]
+        single_genes_imodulons = []
+        for imodulon in self.imodulon_names:
+            sorted_weights = abs(self.M[imodulon]).sort_values(ascending=False)
+            if sorted_weights.iloc[0] > 2*sorted_weights.iloc[1]:
+                single_genes_imodulons.append(imodulon)
+        return single_genes_imodulons
 
     def rename_imodulons(self, name_dict: Dict[ImodName, ImodName]) -> None:
         """

--- a/pymodulon/test/test.py
+++ b/pymodulon/test/test.py
@@ -72,7 +72,7 @@ def test_ica_data_consistency(ica_data):
     assert (ica_data.gene_names[0] == 'b0002')
 
     # check that we can call out single-gene iModulons
-    assert (ica_data.single_gene_imodulons() == [4, 85])
+    assert (ica_data.find_single_gene_imodulons() == [4, 29, 42, 46, 90])
 
     # Check if renaming works for iModulons
     ica_data.rename_imodulons({0: 'YieP'})


### PR DESCRIPTION
Added a simple property to detect single gene iModulons

I decided not to add this to the iModulon table because that gets re-computed in a bunch of different places, and I thought it would be just as easy to manually filter the iModulons to select/remove single-gene iModulons if you had the list of their names in hand. So a bit of an easy way out.

Also includes unrelated commit to use the recompute_thresholds function globally for re-setting the thresholds property.