### PR TITLE
Fix trn

### DIFF
--- a/pymodulon/core.py
+++ b/pymodulon/core.py
@@ -327,7 +327,7 @@ class IcaData(object):
                 self.gene_names)
 
         # make a note that our cutoffs are no longer optimized since the
-        # qTRN has changed
+        # TRN has changed
         self._cutoff_optimized = False
 
     ###############


### PR DESCRIPTION
Loading in the test files from `test.py` into an IcaData obj gave the following error:

![Screen Shot 2020-08-20 at 10 24 15 AM](https://user-images.githubusercontent.com/11781272/90807529-765cee00-e2d3-11ea-9b05-6d7968bfb0f9.png)


This was a bug in how the `reset_index()` method was called and when it was called (as it was overridden at another part in the code).

This pull-request fixes that bug and ensures that the `trn` setter method works as intended. I've tested this on a jupyter notebook by passing in the trn file both as a pandas DataFrame and as a str.

**Note**: This fix is made as the `test.py` file shows the convention that DataFrames that are loaded into the IcaData object are expect to hav their index column be the 0th column (`index_col=0`), and this convention is followed throughout when making the fixes described here. 