### PR TITLE
fix: fix fit_line label not showing

### DIFF
--- a/pymodulon/visualization.py
+++ b/pymodulon/visualization.py
@@ -451,7 +451,7 @@ def scatterplot(x: pd.Series, y: pd.Series,
     ax.set_xlabel(xlabel, **ax_font_kwargs)
     ax.set_ylabel(ylabel, **ax_font_kwargs)
 
-    if legend and legend_kwargs:
+    if (legend and legend_kwargs) or fit_line:
         ax.legend(**legend_kwargs)
 
     return ax


### PR DESCRIPTION
Addresses issue #14 .

Scatterplot now shows Pearson R and p-value:

![image](https://user-images.githubusercontent.com/11781272/91648472-2392dd00-ea1d-11ea-947c-14e5fbbe08ba.png)
