### PR TITLE
ZIP handling for IO functions

### DIFF
--- a/pymodulon/io.py
+++ b/pymodulon/io.py
@@ -1,6 +1,10 @@
 import json
-import pandas as pd
+import os
 from typing import Union, TextIO
+import zipfile
+
+import pandas as pd
+
 from pymodulon.core import IcaData
 
 """
@@ -8,7 +12,7 @@ Functions for reading and writing model into files.
 """
 
 
-def save_to_json(model: IcaData, fname: str):
+def save_to_json(model: IcaData, fname: str, compress: bool = False):
     """
 
     Save model to the json file
@@ -18,7 +22,8 @@ def save_to_json(model: IcaData, fname: str):
        ICA model to be saved to json file
     fname: string
        path to json file where the model will be saved
-
+    compress: bool
+        indicates if the JSON file should be compressed
     """
 
     if model.A is None or model.M is None:
@@ -41,10 +46,18 @@ def save_to_json(model: IcaData, fname: str):
     with open(fname, 'w') as fp:
         json.dump(param_dict, fp)
 
+    # TODO: make this less dumb and write directly to ZIP file
+    if compress:
+        zipfile.ZipFile(
+            f'{fname}.zip',
+            mode='w', compression=zipfile.ZIP_DEFLATED, compresslevel=9
+        ).write(fname)
+        os.remove(fname)
+
 
 def load_json_model(filename: Union[str, TextIO]) -> IcaData:
     """
-    Load a ICA model from a file in JSON format.
+    Load a ICA model from a file in JSON format. Also handles zipped JSON.
     Parameters
     ----------
     filename : str or file-like
@@ -57,8 +70,16 @@ def load_json_model(filename: Union[str, TextIO]) -> IcaData:
 
     """
     if isinstance(filename, str):
-        with open(filename, "r") as file_handle:
-            serial_data = json.load(file_handle)
+        if filename.endswith('.zip'):
+            with zipfile.ZipFile(filename, 'r') as zip_ref:
+                zip_ref.extractall(os.path.dirname(filename))
+            unzipped_file = os.path.splitext(filename)[0]
+            with open(unzipped_file, "r") as file_handle:
+                serial_data = json.load(file_handle)
+            os.remove(unzipped_file)
+        else:
+            with open(filename, "r") as file_handle:
+                serial_data = json.load(file_handle)
     else:
         serial_data = json.load(filename)
     return IcaData(**serial_data)


### PR DESCRIPTION
The JSON file for PRECISE 2.0 is over 100 MB, which makes GitHub reject it by default. I've added some handling for `load_json_model` and `save_to_json` to work with ZIP archives. Specifically, `save_to_json` gets a `compress` option, and `load_json_model` automatically detects if the provided file to load is a `.zip` file. 

When creating/loading the ZIP file, I'm doing it in a fairly dumb way involving the intermediate step of having the bare JSON file existing too; for now, I just delete that after the fact. A bit hacky, but we can iterate and figure out how to directly write JSON to a ZIP archive later perhaps? 