### PR TITLE
Changed Docstrings of compare, core, and io

### DIFF
--- a/src/pymodulon/compare.py
+++ b/src/pymodulon/compare.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import warnings
 from glob import glob
-from typing import Callable, Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd
@@ -22,8 +21,8 @@ def _get_orthologous_imodulons(M1, M2, method, cutoff):
     M2 : ~pandas.DataFrame
         M matrix from the second organism
     method : int or str
-        Correlation metric to use out of {‘pearson’, ‘kendall’, ‘spearman’}
-        or callable
+        Correlation metric to use from {‘pearson’, ‘kendall’, ‘spearman’}
+        or callable (see :meth:`~pandas.DataFrame.corr`)
     cutoff : float
         Cut off value for correlation metric
 
@@ -60,8 +59,8 @@ def _get_orthologous_imodulons(M1, M2, method, cutoff):
 
 def _make_dot_graph(links, show_all, names1, names2):
     """
-    Given two M matrices, returns the dot graph and name links of the various
-    connected ICA components
+    Given a set of links between M matrices, generates a dot graph of the various
+    connected iModulons
 
     Parameters
     ----------
@@ -69,17 +68,15 @@ def _make_dot_graph(links, show_all, names1, names2):
         Names and distances of connected iModulons
     show_all : bool
         Show all iModulons regardless of their linkage (default: False)
-    names1 : list, optional
-        List of names in dataset 1 (required if show_all = True)
+    names1 : list
+        List of names in dataset 1
     names2 : list
-        List of names in dataset 1 (required if show_all = True)
+        List of names in dataset 2
 
     Returns
     -------
     dot: Digraph
         Dot graph of connected iModulons
-    links: list
-        Links and distances of connected iModulons
     """
 
     link_names1 = [link[0] for link in links]
@@ -176,16 +173,16 @@ def convert_gene_index(df1, df2, ortho_file=None, keep_locus=False):
         Dataframe from the first object/organism
     df2 : ~pandas.DataFrame
         Dataframe from the second object/organism
-    ortho_file : str or ~pandas.DataFrame, Optional
+    ortho_file : str or ~pandas.DataFrame, optional
         Path to orthology file between organisms (default: None)
     keep_locus : bool
         If True, keep old locus tags as a column (default: False)
 
     Returns
     -------
-    df1_new: :class:`~pandas.DataFrame`
+    df1_new: ~pandas.DataFrame
         M matrix for organism 1 with indexes translated into orthologs
-    df2_new: :class:`~pandas.DataFrame`
+    df2_new: ~pandas.DataFrame
         M matrix for organism 2 with indexes translated into orthologs
     """
 
@@ -242,8 +239,8 @@ def compare_ica(
     cutoff : float
         Cut off value for correlation metric (default: .25)
     method : str or ~typing.Callable
-        Correlation metric to use out of {‘pearson’, ‘kendall’, ‘spearman’}
-        or callable
+        Correlation metric to use from {‘pearson’, ‘kendall’, ‘spearman’}
+        or callable (see :meth:`~pandas.DataFrame.corr`)
     plot : bool
         Create dot plot of matches (default: True)
     show_all : bool

--- a/src/pymodulon/core.py
+++ b/src/pymodulon/core.py
@@ -4,7 +4,6 @@ Core functions for the IcaData object
 
 import copy
 import re
-from typing import Dict, List, Optional, Sequence, Union
 from warnings import warn
 
 import numpy as np
@@ -53,25 +52,23 @@ class IcaData(object):
 
         Parameters
         ----------
-        M : str or ~pandas.DataFrame or str or ~pandas.DataFrame
-            :class:`~pymodulon.core.M` matrix from ICA
-        A : str or ~pandas.DataFrame or str or ~pandas.DataFrame
-            :class:`~pymodulon.core.A` matrix from ICA
-        X : str or ~pandas.DataFrame or str or ~pandas.DataFrame, optional
+        M : str or ~pandas.DataFrame
+            `M` matrix from ICA
+        A : str or ~pandas.DataFrame
+            `A` matrix from ICA
+        X : str or ~pandas.DataFrame, optional
             log-TPM expression matrix, centered to reference condition(s) (
             default: None)
-        log_tpm : str or ~pandas.DataFrame or str or ~pandas.DataFrame, optional
-            Raw 'log-TPM' expression matrix (without centering) (default: None)
-        gene_table : str or ~pandas.DataFrame or str or ~pandas.DataFrame, optional
+        log_tpm : str or ~pandas.DataFrame, optional
+            Raw `log-TPM` expression matrix (without centering) (default: None)
+        gene_table : str or ~pandas.DataFrame, optional
             Table containing genome annotation (default: None)
-        sample_table : str or ~pandas.DataFrame or str or ~pandas.DataFrame,
-        optional
+        sample_table : str or ~pandas.DataFrame, optional
             Table containing sample metadata (default: None)
-        imodulon_table : str or ~pandas.DataFrame or str or ~pandas.DataFrame,
-        optional
-            Table containing iModulon names, enrichments, and annotations (
-            default: None)
-        trn : str or ~pandas.DataFrame or str or ~pandas.DataFrame, optional
+        imodulon_table : str or ~pandas.DataFrame, optional
+            Table containing iModulon names, enrichments, and annotations
+            (default: None)
+        trn : str or ~pandas.DataFrame, optional
             Table mapping transcriptional regulators to target genes (
             default: None)
         dagostino_cutoff : int
@@ -84,7 +81,7 @@ class IcaData(object):
             the TRN (if provided). This option will be ignored if
             threshold_method is "kmeans" or if custom thresholds are
             provided. (default: False)
-        thresholds : dict or ~typing.Sequence, optional
+        thresholds : dict or list, optional
             Dictionary mapping custom thresholds to iModulons (default: None)
         threshold_method : str
             Either "dagostino" (default with TRN) or "kmeans" (default if no TRN
@@ -103,7 +100,7 @@ class IcaData(object):
             None)
         link_database : str, optional
             Name of the database for the gene_links dictionary (default:
-            "External Database"
+            "External Database")
         """
 
         #########################
@@ -347,12 +344,12 @@ class IcaData(object):
         self._update_imodulon_names(new_names)
 
     @property
-    def sample_names(self) -> List:
+    def sample_names(self):
         """ Get sample names """
         return self._sample_table.index.tolist()
 
     @property
-    def gene_names(self) -> List:
+    def gene_names(self):
         """ Get gene names """
         return self._gene_table.index.tolist()
 
@@ -565,7 +562,7 @@ class IcaData(object):
 
         return final_rows
 
-    def find_single_gene_imodulons(self, save) -> List:
+    def find_single_gene_imodulons(self, save):
         """
         A simple function that returns the names of all likely single-gene
         iModulons. Checks if the largest iModulon gene weight is more
@@ -601,8 +598,7 @@ class IcaData(object):
 
         Parameters
         ----------
-        enrichment : ~pandas.Series or ~pandas.DataFrame
-            iModulon enrichment
+        enrichment : ~pandas.Series or ~pandas.DataFrame iModulon enrichment
 
         Returns
         -------
@@ -637,12 +633,12 @@ class IcaData(object):
 
         Parameters
         ----------
-        imodulon : int or str
+        imodulon: int or str
             Name of 'iModulon'
-        regulator : str
+        regulator: str
             TF name, or complex regulon, where "/" uses genes in any regulon
             and "+" uses genes in all regulons
-        save : bool
+        save: bool
             If true, save enrichment score to the imodulon_table (default: True)
         evidence: list or str
             'Evidence' level of TRN interactions to include during TRN
@@ -936,7 +932,7 @@ class IcaData(object):
 
         Parameters
         ----------
-        dagostino_cutoff : float
+        dagostino_cutoff : int
             New D'agostino cutoff statistic
 
         Returns
@@ -1141,7 +1137,7 @@ class IcaData(object):
 
         return self.M.columns[self.M_binarized.loc[gene] == 1].to_list()
 
-    def name2num(self, gene) -> Union[Sequence[str], str]:
+    def name2num(self, gene):
         """
         Convert a gene name to the locus tag
 
@@ -1187,7 +1183,7 @@ class IcaData(object):
         else:
             return final_list
 
-    def num2name(self, gene: Union[Sequence[str], str]) -> Union[List[str], str]:
+    def num2name(self, gene):
         """
         Get the name of a gene from its locus tag
 

--- a/src/pymodulon/io.py
+++ b/src/pymodulon/io.py
@@ -10,15 +10,15 @@ import pandas as pd
 from pymodulon.core import IcaData
 
 
-def save_to_json(data, fname, compress=False):
+def save_to_json(data, filename, compress=False):
     """
-    Save data to the json file
+    Save :class:`~pymodulon.core.IcaData` object to a json file
 
     Parameters
     ----------
     data: ~pymodulon.core.IcaData
        ICA dataset to be saved to json file
-    fname: str
+    filename: str
        Path to json file where the data will be saved
     compress: bool
         Indicates if the JSON file should be compressed into a gzip archive
@@ -58,21 +58,21 @@ def save_to_json(data, fname, compress=False):
     # Add _cutoff_optimized
     param_dict["_cutoff_optimized"] = data.cutoff_optimized
 
-    if fname.endswith(".gz") or compress:
-        if not fname.endswith(".json.gz"):
-            fname += ".json.gz"
-        with gzip.open(fname, "wt", encoding="ascii") as zipfile:
+    if filename.endswith(".gz") or compress:
+        if not filename.endswith(".json.gz"):
+            filename += ".json.gz"
+        with gzip.open(filename, "wt", encoding="ascii") as zipfile:
             json.dump(param_dict, zipfile)
     else:
-        if not fname.endswith(".json"):
-            fname += ".json"
-        with open(fname, "w") as fp:
+        if not filename.endswith(".json"):
+            filename += ".json"
+        with open(filename, "w") as fp:
             json.dump(param_dict, fp)
 
 
 def load_json_model(filename):
     """
-    Load ICA data from a file in JSON format.
+    Load :class:`~pymodulon.core.IcaData` object from a file in JSON format.
 
     Parameters
     ----------
@@ -83,7 +83,8 @@ def load_json_model(filename):
     Returns
     -------
     IcaData : ~pymodulon.core.IcaData
-        The ICA data as represented in the JSON document.
+        The :class:`~pymodulon.core.IcaData` object as represented in the JSON
+        document.
     """
     if isinstance(filename, str):
         if filename.endswith(".gz"):

--- a/src/pymodulon/util.py
+++ b/src/pymodulon/util.py
@@ -5,7 +5,6 @@ import json
 import re
 import warnings
 from itertools import combinations
-from typing import Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd
@@ -79,7 +78,7 @@ def _check_table_helper(table, index, name):
     return table
 
 
-def _check_dict(table, index_col):
+def _check_dict(table, index_col=0):
     try:
         table = json.loads(table.replace("'", '"'))
     except ValueError:
@@ -97,7 +96,7 @@ def compute_threshold(ic, dagostino_cutoff):
     ----------
     ic: ~pandas.Series
         Pandas Series containing an independent component
-    dagostino_cutoff: float
+    dagostino_cutoff: int
         Minimum D'agostino test statistic value to determine threshold
 
     Returns
@@ -236,7 +235,7 @@ def explained_variance(
         List of samples to use (default: all samples)
     imodulons: list, optional
         List of iModulons to use (default: all iModulons)
-    reference:list, optional
+    reference: list, optional
         List of samples that represent the reference condition for the
         set. If none are provided, uses the dataset-specific reference
         condition.
@@ -318,7 +317,7 @@ def infer_activities(ica_data, data):
 
     Returns
     -------
-    ~pandas.DataFrame
+    new_activities: ~pandas.DataFrame
         Inferred activities for the expression profiles
     """
 


### PR DESCRIPTION
I modified the documentation for core, compare, and io. There is a issues where if a function has two returns, the program doesn't automatically link the types using "~". I used the sphinx function call to force a link, but I can easily change it if it doesn't look good. Also let me know if there are any other issues that need to be addressed