### PR TITLE
feat: add savefig option to barplot, scatterplot

### DIFF
--- a/src/pymodulon/plotting.py
+++ b/src/pymodulon/plotting.py
@@ -82,6 +82,9 @@ def barplot(
     if ax is None:
         figsize = (len(values) / 15 + 0.5, 2)
         fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = plt.gcf()
+        ax = plt.gca()
 
     # Get ymin and max
     ymin = values.min()
@@ -211,15 +214,7 @@ def barplot(
 
     # Save figure
     if savefig:
-        if savefig_kwargs:
-            fname = savefig_kwargs.get('fname')
-            if fname is None:
-                savefig_kwargs['fname'] = './plot.svg'
-
-        else:
-            savefig_kwargs = {'fname': './plot.svg'}
-
-        plt.savefig(**savefig_kwargs)
+        _save_figures(fig, savefig_kwargs)
 
     return ax
 
@@ -587,6 +582,9 @@ def scatterplot(
 
     if ax is None:
         fig, ax = plt.subplots()
+    else:
+        fig = plt.gcf()
+        ax = plt.gca()
 
     if show_labels == "auto":
         show_labels = len(x) <= 20
@@ -746,15 +744,7 @@ def scatterplot(
 
     # Save figure
     if savefig:
-        if savefig_kwargs:
-            fname = savefig_kwargs.get('fname')
-            if fname is None:
-                savefig_kwargs['fname'] = './plot.svg'
-
-        else:
-            savefig_kwargs = {'fname': './plot.svg'}
-
-        plt.savefig(**savefig_kwargs)
+        _save_figures(fig, savefig_kwargs)
 
     return ax
 
@@ -2118,6 +2108,18 @@ def _mod_freedman_diaconis(ica_data, imodulon):
 
     return np.arange(xmin, xmax + width, width)
 
+
+def _save_figures(fig, savefig_kwargs):
+    '''Check for savefig_kwargs, then save current figure instance'''
+
+    # Check for savefig_kwargs
+    if savefig_kwargs:
+            savefig_kwargs['fname'] = savefig_kwargs.get('fname', './plot.svg')
+    else:
+        savefig_kwargs = {'fname': './plot.svg'}
+
+    # Plot current figure instance using savefig_kwargs
+    fig.savefig(**savefig_kwargs)
 
 ##########################
 # Experimental Functions #

--- a/src/pymodulon/plotting.py
+++ b/src/pymodulon/plotting.py
@@ -38,6 +38,8 @@ def barplot(
     highlight=None,
     ax=None,
     legend_kwargs=None,
+    savefig=False,
+    savefig_kwargs=None
 ):
     """
     Creates an overlaid scatter and barplot for a set of values (either gene
@@ -206,6 +208,18 @@ def barplot(
 
     # X-axis
     ax.hlines(0, xmin, xmax, color="k")
+
+    # Save figure
+    if savefig:
+        if savefig_kwargs:
+            fname = savefig_kwargs.get('fname')
+            if fname is None:
+                savefig_kwargs['fname'] = './plot.svg'
+
+        else:
+            savefig_kwargs = {'fname': './plot.svg'}
+
+        plt.savefig(**savefig_kwargs)
 
     return ax
 
@@ -516,6 +530,8 @@ def scatterplot(
     scatter_kwargs=None,
     label_font_kwargs=None,
     legend_kwargs=None,
+    savefig=False,
+    savefig_kwargs=None
 ):
     """
     Generates a scatter-plot of the data given, with options for coloring by
@@ -727,6 +743,18 @@ def scatterplot(
 
     if legend or fit_line:
         ax.legend(**legend_kwargs)
+
+    # Save figure
+    if savefig:
+        if savefig_kwargs:
+            fname = savefig_kwargs.get('fname')
+            if fname is None:
+                savefig_kwargs['fname'] = './plot.svg'
+
+        else:
+            savefig_kwargs = {'fname': './plot.svg'}
+
+        plt.savefig(**savefig_kwargs)
 
     return ax
 


### PR DESCRIPTION
Added `savefig` and `savefig_kwargs` options to `barplot()` and `scatterplot()` functions.

Goal:
If savefig is True, the plot is saved using the `plt.savefig()` method with savefig_kwargs being passed onto that function. If fname is not provided (or if savefig_kwargs is not provided), an fname is chosen automatically `./plot.svg` and passed down instead.