### PR TITLE
Remove savefig

### DIFF
--- a/src/pymodulon/plotting.py
+++ b/src/pymodulon/plotting.py
@@ -37,9 +37,7 @@ def barplot(
     projects=None,
     highlight=None,
     ax=None,
-    savefig=False,
-    legend_kwargs=None,
-    savefig_kwargs=None,
+    legend_kwargs=None
 ):
     """
     Creates an overlaid scatter and barplot for a set of values (either gene
@@ -216,10 +214,6 @@ def barplot(
     # X-axis
     ax.hlines(0, xmin, xmax, color="k")
 
-    # Save figure
-    if savefig:
-        _save_figures(fig, savefig, savefig_kwargs)
-
     return ax
 
 
@@ -229,9 +223,7 @@ def plot_expression(
     projects=None,
     highlight=None,
     ax=None,
-    savefig=False,
-    legend_kwargs=None,
-    savefig_kwargs=None,
+    legend_kwargs=None
 ):
     """
     Creates a barplot showing an gene's expression across the compendium
@@ -277,9 +269,7 @@ def plot_expression(
         projects=projects,
         highlight=highlight,
         ax=ax,
-        savefig=savefig,
-        legend_kwargs=legend_kwargs,
-        savefig_kwargs=savefig_kwargs,
+        legend_kwargs=legend_kwargs
     )
 
 
@@ -289,9 +279,7 @@ def plot_activities(
     projects=None,
     highlight=None,
     ax=None,
-    savefig=False,
-    legend_kwargs=None,
-    savefig_kwargs=None,
+    legend_kwargs=None
 ):
     """
     Creates a barplot showing an iModulon's activity across the compendium
@@ -336,9 +324,7 @@ def plot_activities(
         projects=projects,
         highlight=highlight,
         ax=ax,
-        savefig=savefig,
-        legend_kwargs=legend_kwargs,
-        savefig_kwargs=savefig_kwargs,
+        legend_kwargs=legend_kwargs
     )
 
 
@@ -348,9 +334,7 @@ def plot_metadata(
     projects=None,
     highlight=None,
     ax=None,
-    savefig=False,
-    legend_kwargs=None,
-    savefig_kwargs=None,
+    legend_kwargs=None
 ):
     """
     Creates a barplot for values in the sample table
@@ -400,9 +384,7 @@ def plot_metadata(
         projects=projects,
         highlight=highlight,
         ax=ax,
-        savefig=savefig,
-        legend_kwargs=legend_kwargs,
-        savefig_kwargs=savefig_kwargs,
+        legend_kwargs=legend_kwargs
     )
 
 
@@ -416,10 +398,8 @@ def plot_regulon_histogram(
     hist_label=("Not regulated", "Regulon Genes"),
     color=("#aaaaaa", "salmon"),
     alpha=0.7,
-    savefig=False,
     ax_font_kwargs=None,
-    legend_kwargs=None,
-    savefig_kwargs=None,
+    legend_kwargs=None
 ):
     """
     Plots a histogram of regulon vs non-regulon genes by iModulon weighting.
@@ -569,10 +549,6 @@ def plot_regulon_histogram(
     # Add legend
     ax.legend(**legend_kwargs)
 
-    # Save figure
-    if savefig:
-        _save_figures(fig, savefig, savefig_kwargs)
-
     return ax
 
 
@@ -596,12 +572,10 @@ def scatterplot(
     ylabel="",
     ax=None,
     legend=True,
-    savefig=False,
     ax_font_kwargs=None,
     scatter_kwargs=None,
     label_font_kwargs=None,
-    legend_kwargs=None,
-    savefig_kwargs=None,
+    legend_kwargs=None
 ):
     """
     Generates a scatter-plot of the data given, with options for coloring by
@@ -819,10 +793,6 @@ def scatterplot(
 
     if legend or fit_line:
         ax.legend(**legend_kwargs)
-
-    # Save figure
-    if savefig:
-        _save_figures(fig, savefig, savefig_kwargs)
 
     return ax
 
@@ -1419,7 +1389,7 @@ def plot_dima(
 
 # TODO: Add kind=bar to plot top explained variance
 def plot_explained_variance(
-    ica_data, pc=True, ax=None, savefig=False, savefig_kwargs=None
+    ica_data, pc=True, ax=None
 ):
     """
     Plots the cumulative explained variance for independent components and,
@@ -1475,10 +1445,6 @@ def plot_explained_variance(
     ax.set_ylim([0, 1])
     ax.set_xlim([0, len(ic_var)])
 
-    # Save figure
-    if savefig:
-        _save_figures(fig, savefig, savefig_kwargs)
-
     return ax
 
 
@@ -1494,11 +1460,9 @@ def compare_imodulons_vs_regulons(
     vline=0.6,
     hline=0.6,
     ax=None,
-    savefig=False,
     scatter_kwargs=None,
     ax_font_kwargs=None,
-    legend_kwargs=None,
-    savefig_kwargs=None,
+    legend_kwargs=None
 ):
     """
     Compare the overlaps between iModulons and their linked regulons
@@ -1650,10 +1614,6 @@ def compare_imodulons_vs_regulons(
     # Set legend
     bbox_to_anchor_ivr = legend_kwargs.pop("bbox_to_anchor", (1, 1))
     ax.legend(bbox_to_anchor=bbox_to_anchor_ivr, **legend_kwargs)
-
-    # Save figure
-    if savefig:
-        _save_figures(fig, savefig, savefig_kwargs)
 
     return ax
 
@@ -2101,11 +2061,9 @@ def metadata_boxplot(
     use_cols=None,
     return_results=False,
     ax=None,
-    savefig=False,
     box_kwargs=None,
     strip_kwargs=None,
-    swarm_kwargs=None,
-    savefig_kwargs=None,
+    swarm_kwargs=None
 ):
     """
     Uses a decision tree regressor to automatically cluster iModulon activities
@@ -2218,10 +2176,6 @@ def metadata_boxplot(
         )
 
     ax.set_ylabel("")
-
-    # Save Figure
-    if savefig:
-        _save_figures(fig, savefig, savefig_kwargs)
 
     if return_results:
         return ax, df_classes
@@ -2479,21 +2433,6 @@ def _mod_freedman_diaconis(ica_data, imodulon):
         xmax = thresh + width
 
     return np.arange(xmin, xmax + width, width)
-
-
-def _save_figures(fig, filename, savefig_kwargs):
-    """Helper function for saving figures as files"""
-
-    if savefig_kwargs is None:
-        savefig_kwargs = {}
-
-    if isinstance(filename, str):
-        savefig_kwargs["fname"] = filename
-    elif "fname" not in savefig_kwargs.keys():
-        savefig_kwargs["fname"] = "./plot.svg"
-
-    # Plot current figure instance using savefig_kwargs
-    fig.savefig(**savefig_kwargs)
 
 
 ##########################

--- a/src/pymodulon/plotting.py
+++ b/src/pymodulon/plotting.py
@@ -57,13 +57,8 @@ def barplot(
         Project(s) to `highlight` (default: None)
     ax: ~matplotlib.axes.Axes, optional
         Axes object to plot on, otherwise use current Axes
-    savefig: str or bool
-        Save figure to provided path
     legend_kwargs: dict, optional
         Additional keyword arguments passed to :func:`matplotlib.pyplot.legend`
-    savefig_kwargs: dict, optional
-        Additional keyword arguments passed to :func:`matplotlib.pyplot.savefig`
-
 
     Returns
     -------
@@ -85,8 +80,6 @@ def barplot(
     if ax is None:
         figsize = (len(values) / 15 + 0.5, 2)
         fig, ax = plt.subplots(figsize=figsize)
-    else:
-        fig = ax.figure
 
     # Get ymin and max
     ymin = values.min()
@@ -240,12 +233,8 @@ def plot_expression(
         Name(s) of projects to `highlight` (default: None)
     ax: ~matplotlib.axes.Axes, optional
         Axes object to plot on, otherwise use current Axes
-    savefig: str or bool, optional
-        Save figure to provided path
     legend_kwargs: dict, optional
         Additional keyword arguments passed to :func:`matplotlib.pyplot.legend`
-    savefig_kwargs: dict, optional
-        Additional keyword arguments passed to :func:`matplotlib.pyplot.savefig`
 
     Returns
     -------
@@ -296,12 +285,8 @@ def plot_activities(
         Name(s) of projects to `highlight` (default: None)
     ax: ~matplotlib.axes.Axes, optional
         Axes object to plot on, otherwise use current Axes
-    savefig: str or bool, optional
-        Save figure to provided path
     legend_kwargs: dict, optional
         Additional keyword arguments passed to :func:`matplotlib.pyplot.legend`
-    savefig_kwargs: dict, optional
-        Additional keyword arguments passed to :func:`matplotlib.pyplot.savefig`
 
     Returns
     -------
@@ -351,12 +336,8 @@ def plot_metadata(
         Name(s) of projects to `highlight` (default: None)
     ax: ~matplotlib.axes.Axes, optional
         Axes object to plot on, otherwise use current Axes
-    savefig: str or bool, optional
-        Save figure to provided path
     legend_kwargs: dict, optional
         Additional keyword arguments passed to :func:`matplotlib.pyplot.legend`
-    savefig_kwargs: dict, optional
-        Additional keyword arguments passed to :func:`matplotlib.pyplot.savefig`
 
     Returns
     -------
@@ -432,14 +413,10 @@ def plot_regulon_histogram(
     alpha: float, optional
         Sets the opacity of the histogram (0 = transparent, 1 = opaque).
         Passed on to :func:`matplotlib.pyplot.hist`
-    savefig: str or bool, optional
-        Save figure to provided path
     ax_font_kwargs: dict, optional
         Additional keyword arguments for axes labels
     legend_kwargs: dict, optional
         Additional keyword arguments passed to :func:`matplotlib.pyplot.legend`
-    savefig_kwargs: dict, optional
-        Additional keyword arguments passed to :func:`matplotlib.pyplot.savefig`
 
     Returns
     -------
@@ -454,8 +431,6 @@ def plot_regulon_histogram(
     # If ax is None, create ax on which to generate histogram
     if ax is None:
         fig, ax = plt.subplots()
-    else:
-        fig = ax.figure
 
     # If bins is None, generate optimal number of bins
     if bins is None:
@@ -613,8 +588,6 @@ def scatterplot(
         Axes object to plot on, otherwise use current Axes
     legend: bool
         Show legend
-    savefig: str or bool, optional
-        Save figure to provided path
     ax_font_kwargs: dict, optional
         Additional keyword arguments for axis labels
     scatter_kwargs: dict, optional
@@ -624,8 +597,6 @@ def scatterplot(
         :func:`matplotlib.pyplot.text`
     legend_kwargs: dict, optional
         Additional keyword arguments passed to :func:`matplotlib.pyplot.legend`
-    savefig_kwargs: dict, optional
-        Additional keyword arguments passed to :func:`matplotlib.pyplot.savefig`
 
     Returns
     -------
@@ -635,8 +606,6 @@ def scatterplot(
 
     if ax is None:
         fig, ax = plt.subplots()
-    else:
-        fig = ax.figure
 
     if show_labels == "auto":
         show_labels = len(x) <= 20
@@ -1403,10 +1372,6 @@ def plot_explained_variance(
         If True, plot cumulative explained variance of independent components
     ax: ~matplotlib.axes.Axes, optional
         Axes object to plot on, otherwise use current Axes
-    savefig: str or bool, optional
-        Save figure to provided path
-    savefig_kwargs: dict, optional
-        Additional keyword arguments passed to :func:`matplotlib.pyplot.savefig`
 
     Returns
     -------
@@ -1416,8 +1381,6 @@ def plot_explained_variance(
 
     if not ax:
         fig, ax = plt.subplots()
-    else:
-        fig = ax.figure
 
     # Get IC explained variance
     ic_var = []
@@ -1492,16 +1455,12 @@ def compare_imodulons_vs_regulons(
         Draw a dashed horizontal line
     ax: ~matplotlib.axes.Axes, optional
         Axes object to plot on, otherwise use current Axes
-    savefig: str or bool, optional
-        Save figure to provided path
     scatter_kwargs: dict, optional
         Additional keyword arguments passed to :func:`matplotlib.pyplot.scatter`
     ax_font_kwargs: dict, optional
         Additional keyword arguments for axes labels
     legend_kwargs: dict, optional
         Additional keyword arguments passed to :func:`matplotlib.pyplot.legend`
-    savefig_kwargs: dict, optional
-        Additional keyword arguments passed to :func:`matplotlib.pyplot.savefig`
 
     Returns
     -------
@@ -1512,8 +1471,6 @@ def compare_imodulons_vs_regulons(
     # Set up axis
     if not ax:
         fig, ax = plt.subplots(figsize=(5, 5))
-    else:
-        fig = ax.figure
 
     # Handle kwargs
     if scatter_kwargs is None:
@@ -1622,7 +1579,6 @@ def compare_imodulons_vs_regulons(
 # Cluster Activities #
 ######################
 
-# TODO: Figure out savefig for this plot
 def cluster_activities(
     ica_data,
     correlation_method="spearman",
@@ -2095,16 +2051,12 @@ def metadata_boxplot(
         Return a dataframe describing the classifications
     ax: ~matplotlib.axes.Axes, optional
         Axes object to plot on, otherwise use current Axes
-    savefig: str or bool, optional
-        Save figure to provided path
     box_kwargs: dict, optional
         Additional keyword arguments passed to :func:`seaborn.boxplot`
     strip_kwargs: dict, optional
         Additional keyword arguments passed to :func:`seaborn.stripplot`
     swarm_kwargs: dict, optional
         Additional keyword arguments passed to :func:`seaborn.swarmplot`
-    savefig_kwargs: dict, optional
-        Additional keyword arguments passed to :func:`matplotlib.pyplot.savefig`
 
     Returns
     -------
@@ -2116,8 +2068,6 @@ def metadata_boxplot(
 
     if not ax:
         fig, ax = plt.subplots()
-    else:
-        fig = ax.figure
 
     if show_points is True:
         show_points = "strip"

--- a/src/pymodulon/plotting.py
+++ b/src/pymodulon/plotting.py
@@ -1540,7 +1540,7 @@ def compare_imodulons_vs_regulons(
     if imodulons is None:
         reg_table = ica_data.imodulon_table.copy()
         if reg_only:
-            reg_table = imodulon_table[imodulon_table.regulator.notnull()]
+            reg_table = reg_table[reg_table.regulator.notnull()]
     else:
         reg_table = ica_data.imodulon_table.loc[imodulons]
 

--- a/src/pymodulon/plotting.py
+++ b/src/pymodulon/plotting.py
@@ -37,7 +37,7 @@ def barplot(
     projects=None,
     highlight=None,
     ax=None,
-    legend_kwargs=None
+    legend_kwargs=None,
 ):
     """
     Creates an overlaid scatter and barplot for a set of values (either gene
@@ -211,12 +211,7 @@ def barplot(
 
 
 def plot_expression(
-    ica_data,
-    gene,
-    projects=None,
-    highlight=None,
-    ax=None,
-    legend_kwargs=None
+    ica_data, gene, projects=None, highlight=None, ax=None, legend_kwargs=None
 ):
     """
     Creates a barplot showing an gene's expression across the compendium
@@ -258,17 +253,12 @@ def plot_expression(
         projects=projects,
         highlight=highlight,
         ax=ax,
-        legend_kwargs=legend_kwargs
+        legend_kwargs=legend_kwargs,
     )
 
 
 def plot_activities(
-    ica_data,
-    imodulon,
-    projects=None,
-    highlight=None,
-    ax=None,
-    legend_kwargs=None
+    ica_data, imodulon, projects=None, highlight=None, ax=None, legend_kwargs=None
 ):
     """
     Creates a barplot showing an iModulon's activity across the compendium
@@ -309,17 +299,12 @@ def plot_activities(
         projects=projects,
         highlight=highlight,
         ax=ax,
-        legend_kwargs=legend_kwargs
+        legend_kwargs=legend_kwargs,
     )
 
 
 def plot_metadata(
-    ica_data,
-    column,
-    projects=None,
-    highlight=None,
-    ax=None,
-    legend_kwargs=None
+    ica_data, column, projects=None, highlight=None, ax=None, legend_kwargs=None
 ):
     """
     Creates a barplot for values in the sample table
@@ -365,7 +350,7 @@ def plot_metadata(
         projects=projects,
         highlight=highlight,
         ax=ax,
-        legend_kwargs=legend_kwargs
+        legend_kwargs=legend_kwargs,
     )
 
 
@@ -380,7 +365,7 @@ def plot_regulon_histogram(
     color=("#aaaaaa", "salmon"),
     alpha=0.7,
     ax_font_kwargs=None,
-    legend_kwargs=None
+    legend_kwargs=None,
 ):
     """
     Plots a histogram of regulon vs non-regulon genes by iModulon weighting.
@@ -550,7 +535,7 @@ def scatterplot(
     ax_font_kwargs=None,
     scatter_kwargs=None,
     label_font_kwargs=None,
-    legend_kwargs=None
+    legend_kwargs=None,
 ):
     """
     Generates a scatter-plot of the data given, with options for coloring by
@@ -1357,9 +1342,7 @@ def plot_dima(
 ###############
 
 # TODO: Add kind=bar to plot top explained variance
-def plot_explained_variance(
-    ica_data, pc=True, ax=None
-):
+def plot_explained_variance(ica_data, pc=True, ax=None):
     """
     Plots the cumulative explained variance for independent components and,
     optionally, principal components
@@ -1425,7 +1408,7 @@ def compare_imodulons_vs_regulons(
     ax=None,
     scatter_kwargs=None,
     ax_font_kwargs=None,
-    legend_kwargs=None
+    legend_kwargs=None,
 ):
     """
     Compare the overlaps between iModulons and their linked regulons
@@ -1578,6 +1561,7 @@ def compare_imodulons_vs_regulons(
 ######################
 # Cluster Activities #
 ######################
+
 
 def cluster_activities(
     ica_data,
@@ -2019,7 +2003,7 @@ def metadata_boxplot(
     ax=None,
     box_kwargs=None,
     strip_kwargs=None,
-    swarm_kwargs=None
+    swarm_kwargs=None,
 ):
     """
     Uses a decision tree regressor to automatically cluster iModulon activities


### PR DESCRIPTION
Remove the `savefig` option. While useful, it has some bugs in it and it may just be better to utilize `matplotlib`'s default API to save plots instead.

Also fixed a small error with an unresolved reference in a plot (wrong variable was being used in one line)