### PR TITLE
Minor iMdb changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,14 +40,14 @@ Installation
 With Docker
 ~~~~~~~~~~~
 
-The easiest way to get started with PyModulon is using the Docker container. 
+The easiest way to get started with PyModulon is using the Docker container.
 
 1. Install `Docker <https://docs.docker.com/get-docker/>`_
 2. Open terminal and navigate to your work folder
 3. Run the following commands to start a Jupyter notebook server::
 
 	docker run -p 8888:8888 -v "${PWD}":/home/jovyan/work sbrg/pymodulon
-	
+
 4. Copy the URL from terminal to connect to the Jupyter notebook
 5. Navigate to the ``work`` folder, which has your current directory mounted.
 6. To close the notebook, press ``Ctrl+C`` in terminal
@@ -58,7 +58,7 @@ With Pip
 You can install PyModulon from `PyPI <https://pypi.org/project/pymodulon/>`_ using ``pip`` as follows::
 
         python -m pip install pymodulon
-	
+
 With Conda
 ~~~~~~~~~~
 
@@ -95,14 +95,14 @@ We recommend using an editable pip installation for development::
 	git clone https://github.com/SBRG/pymodulon.git
 	cd pymodulon
 	python -m pip install -e .
-	
+
 This method of installation will automatically update your
 package each time you pull from this repository.
 
 To update your code, run the following from your local **PyModulon** folder::
 
 	git pull
-	
+
 
 Cite
 ----

--- a/src/pymodulon/imodulondb.py
+++ b/src/pymodulon/imodulondb.py
@@ -186,13 +186,14 @@ def imodulondb_compatibility(model, inplace=False, tfcomplex_to_gene=None):
     if model.sample_table.columns.str.lower().duplicated().any():
         logging.warning(
             "Critical issue: Duplicated column names"
-            " (case insensitive) in sample_table")
+            " (case insensitive) in sample_table"
+        )
         table_issues = table_issues.append(
             {
                 "Table": "Sample",
                 "Missing Column": "N/A - Duplicated Columns Exist",
                 "Solution": "Column names (case insensitive) should not "
-                    "be duplicated. Pay special attention the 'sample' column."
+                "be duplicated. Pay special attention the 'sample' column.",
             },
             ignore_index=True,
         )
@@ -328,8 +329,14 @@ def imodulondb_compatibility(model, inplace=False, tfcomplex_to_gene=None):
     return table_issues, tf_issues, missing_g_links, missing_DOIs
 
 
-def imodulondb_export(model, path=".", cat_order=None, tfcomplex_to_gene=None,
-    skip_iMs=False, skip_genes=False):
+def imodulondb_export(
+    model,
+    path=".",
+    cat_order=None,
+    tfcomplex_to_gene=None,
+    skip_iMs=False,
+    skip_genes=False,
+):
 
     """
     Generates the iModulonDB page for the data and exports to the path.
@@ -359,10 +366,6 @@ def imodulondb_export(model, path=".", cat_order=None, tfcomplex_to_gene=None,
     None: None
     """
 
-    # silence warnings
-    pd_option = pd.options.mode.chained_assignment
-    pd.options.mode.chained_assignment = None
-
     if tfcomplex_to_gene is None:
         tfcomplex_to_gene = {}
     model1 = model.copy()
@@ -374,18 +377,18 @@ def imodulondb_export(model, path=".", cat_order=None, tfcomplex_to_gene=None,
 
     print("Done writing main site files. Writing plot files...")
 
-    if not(skip_iMs and skip_genes):
+    if not (skip_iMs and skip_genes):
         print(
             "Two progress bars will appear below. The second will take "
             "significantly longer than the first."
         )
 
-    if not(skip_iMs):
+    if not (skip_iMs):
         print("Writing iModulon page files (1/2)")
 
         imdb_generate_im_files(model1, folder, "start", tfcomplex_to_gene)
 
-    if not(skip_genes):
+    if not (skip_genes):
         print("Writing Gene page files (2/2)")
 
         imdb_generate_gene_files(model1, folder)
@@ -396,9 +399,6 @@ def imodulondb_export(model, path=".", cat_order=None, tfcomplex_to_gene=None,
             model1.imodulondb_table["dataset_folder"],
         )
     )
-
-    # reset warnings
-    pd.options.mode.chained_assignment = pd_option
 
 
 ###############################
@@ -485,7 +485,7 @@ def imdb_iM_table(imodulon_table, cat_order=None):
             "precision",
             "recall",
         ]
-    ]
+    ].copy()
     im_table.index.name = "k"
     im_table.category = im_table.category.fillna("Uncharacterized")
 
@@ -1581,8 +1581,8 @@ def imdb_regulon_scatter_df(model, k, tfcomplex_to_genename=None):
     res = res.sort_values("R2", axis=1, ascending=False)
     res = res[pd.Index(["A"]).append(res.columns.drop("A"))]
 
-    if 'sample' in model.sample_table.columns:
-        res = res.rename(model.sample_table['sample'].to_dict())
+    if "sample" in model.sample_table.columns:
+        res = res.rename(model.sample_table["sample"].to_dict())
 
     return res
 
@@ -1832,8 +1832,8 @@ def make_im_directory(
         reg_scatter.to_csv(folder + str(k) + "_reg_scatter.csv")
     model.M[k].to_csv(folder + str(k) + "_gene_weights.csv")
     a_k = model.A.loc[k]
-    if 'sample' in model.sample_table.columns:
-        a_k.index = a_k.index.to_series().map(model.sample_table['sample'].to_dict())
+    if "sample" in model.sample_table.columns:
+        a_k.index = a_k.index.to_series().map(model.sample_table["sample"].to_dict())
     a_k.to_csv(folder + str(k) + "_activity.csv")
 
 

--- a/src/pymodulon/imodulondb.py
+++ b/src/pymodulon/imodulondb.py
@@ -183,6 +183,20 @@ def imodulondb_compatibility(model, inplace=False, tfcomplex_to_gene=None):
     }
     sample_table_lower = {i.lower(): i for i in model.sample_table.columns}
 
+    if model.sample_table.columns.str.lower().duplicated().any():
+        logging.warning(
+            "Critical issue: Duplicated column names"
+            " (case insensitive) in sample_table")
+        table_issues = table_issues.append(
+            {
+                "Table": "Sample",
+                "Missing Column": "N/A - Duplicated Columns Exist",
+                "Solution": "Column names (case insensitive) should not "
+                    "be duplicated. Pay special attention the 'sample' column."
+            },
+            ignore_index=True,
+        )
+
     for col in sample_table_cols.keys():
         if not (col in sample_table_lower.keys()):
 
@@ -314,7 +328,9 @@ def imodulondb_compatibility(model, inplace=False, tfcomplex_to_gene=None):
     return table_issues, tf_issues, missing_g_links, missing_DOIs
 
 
-def imodulondb_export(model, path=".", cat_order=None, tfcomplex_to_gene=None):
+def imodulondb_export(model, path=".", cat_order=None, tfcomplex_to_gene=None,
+    skip_iMs=False, skip_genes=False):
+
     """
     Generates the iModulonDB page for the data and exports to the path.
     If certain columns are unavailable but can be filled in automatically,
@@ -333,11 +349,19 @@ def imodulondb_export(model, path=".", cat_order=None, tfcomplex_to_gene=None):
         dictionary pointing complex TRN entries
         to matching gene names in the gene table
         ex: {"FlhDC":"flhD"}
+    skip_iMs : bool, optional
+        If this is True, do not output iModulon files (to save time)
+    skip_genes : bool, optional
+        If this is True, do not output gene files (to save time)
 
     Returns
     -------
     None: None
     """
+
+    # silence warnings
+    pd_option = pd.options.mode.chained_assignment
+    pd.options.mode.chained_assignment = None
 
     if tfcomplex_to_gene is None:
         tfcomplex_to_gene = {}
@@ -350,18 +374,21 @@ def imodulondb_export(model, path=".", cat_order=None, tfcomplex_to_gene=None):
 
     print("Done writing main site files. Writing plot files...")
 
-    print(
-        "Two progress bars will appear below. The second will take "
-        "significantly longer than the first."
-    )
+    if not(skip_iMs and skip_genes):
+        print(
+            "Two progress bars will appear below. The second will take "
+            "significantly longer than the first."
+        )
 
-    print("Writing iModulon page files (1/2)")
+    if not(skip_iMs):
+        print("Writing iModulon page files (1/2)")
 
-    imdb_generate_im_files(model1, folder, "start", tfcomplex_to_gene)
+        imdb_generate_im_files(model1, folder, "start", tfcomplex_to_gene)
 
-    print("Writing Gene page files (2/2)")
+    if not(skip_genes):
+        print("Writing Gene page files (2/2)")
 
-    imdb_generate_gene_files(model1, folder)
+        imdb_generate_gene_files(model1, folder)
 
     print(
         "Complete! (Organism = {}; Dataset = {})".format(
@@ -369,6 +396,9 @@ def imodulondb_export(model, path=".", cat_order=None, tfcomplex_to_gene=None):
             model1.imodulondb_table["dataset_folder"],
         )
     )
+
+    # reset warnings
+    pd.options.mode.chained_assignment = pd_option
 
 
 ###############################
@@ -1551,6 +1581,9 @@ def imdb_regulon_scatter_df(model, k, tfcomplex_to_genename=None):
     res = res.sort_values("R2", axis=1, ascending=False)
     res = res[pd.Index(["A"]).append(res.columns.drop("A"))]
 
+    if 'sample' in model.sample_table.columns:
+        res = res.rename(model.sample_table['sample'].to_dict())
+
     return res
 
 
@@ -1798,7 +1831,10 @@ def make_im_directory(
     if not (reg_scatter is None):
         reg_scatter.to_csv(folder + str(k) + "_reg_scatter.csv")
     model.M[k].to_csv(folder + str(k) + "_gene_weights.csv")
-    model.A.loc[k].to_csv(folder + str(k) + "_activity.csv")
+    a_k = model.A.loc[k]
+    if 'sample' in model.sample_table.columns:
+        a_k.index = a_k.index.to_series().map(model.sample_table['sample'].to_dict())
+    a_k.to_csv(folder + str(k) + "_activity.csv")
 
 
 ###############################################


### PR DESCRIPTION
Regulon scatter labels are now always human readable (sample column instead of index)
Settingwithcopywarning suppressed while using imodulondb_export
Can now turn off parts of export (iMs/genes only)