### PR TITLE
fix: update COG category mapping

### DIFF
--- a/src/pymodulon/gene_util.py
+++ b/src/pymodulon/gene_util.py
@@ -49,9 +49,10 @@ def cog2str(cog):
         "U": "Intracellular trafficking, secretion, and vesicular transport",
         "V": "Defense mechanisms",
         "W": "Extracellular structures",
-        "X": "No COG annotation",
+        "X": "Mobilome: prophages, transposons",
         "Y": "Nuclear structure",
         "Z": "Cytoskeleton",
+        "-": "No COG annotation",
     }
 
     return cog_dict[cog]


### PR DESCRIPTION
Update COG mapping. We originally used `X` for genes with no COG category but that is unfortunately incorrect (see `https://www.ncbi.nlm.nih.gov/research/cog/cogcategory/X/#`). `X` is actually a COG category which deals with the mobilome (prophages, transposons, and the like).

I've updated the cog_dict in `gene_util` to reflect this, and added `-` to represent genes with no COG annotation