### PR TITLE
fix: allow for plotting to use sets as indexers

### DIFF
--- a/src/pymodulon/plotting.py
+++ b/src/pymodulon/plotting.py
@@ -833,7 +833,7 @@ def plot_gene_weights(ica_data, imodulon, by="start", xaxis=None, xname="", **kw
 
     # Update colors for COG groups
     if "COG" in ica_data.gene_table.columns and "groups" not in kwargs:
-        mod_cogs = ica_data.gene_table.loc[component_genes].COG
+        mod_cogs = ica_data.gene_table.loc[list(component_genes)].COG
         hidden_cogs = pd.Series("hidden", index=other_genes)
         all_cogs = pd.concat([mod_cogs, hidden_cogs])
         # colors = {cog:ica_data.cog_colors[cog] for cog in sorted(mod_cogs.unique())}


### PR DESCRIPTION
Plotting was not working for some versions of pymodulon as the pandas dependency only indexes with lists and tuples in some cases. `component_genes` has been typecast to a list for avoid this.